### PR TITLE
create `Model` and `BaseModel` classes

### DIFF
--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
-from enum import Enum, IntFlag
 from typing import Optional, List, Any
+from enum import IntFlag
 
-from ossapi.utils import ListEnumMeta, Datetime
+from ossapi.utils import EnumModel, ListEnumMeta, Datetime, Model, BaseModel
 
 # ================
 # Documented Enums
 # ================
 
-class ProfilePage(Enum):
+class ProfilePage(EnumModel):
     ME = "me"
     RECENT_ACTIVITY = "recent_activity"
     BEATMAPS = "beatmaps"
@@ -17,29 +17,35 @@ class ProfilePage(Enum):
     TOP_RANKS = "top_ranks"
     MEDALS = "medals"
 
-class GameMode(Enum):
+class GameMode(EnumModel):
     STD    = "osu"
     TAIKO  = "taiko"
     CTB    = "fruits"
     MANIA  = "mania"
 
-class ScoreType(Enum):
+class ScoreType(EnumModel):
     BEST = "best"
     FIRST = "first"
     RECENT = "recent"
 
-class RankingFilter(Enum):
+class RankingFilter(EnumModel):
     ALL = "all"
     FRIENDS = "friends"
 
-class RankingType(Enum):
+class RankingType(EnumModel):
     CHARTS = "spotlight"
     COUNTRY = "country"
     PERFORMANCE = "performance"
     SCORE = "score"
 
-
-class PlayStyles(IntFlag, metaclass=ListEnumMeta):
+# for reasons I don't fully understand, we can't do
+# ``PlayStyles(IntFlagModel, metaclass=ListEnumMeta)`` and must instead do this,
+# with two separate classes. Possibly because when using an enum metaclass, its
+# superclass must be a direct enum class like ``IntFlag``, and not a subclass
+# like ``IntFlagModel``? Weird territory here.
+# The error thrown when using ``IntFlagModel`` is:
+# ``TypeError: object.__new__(PlayStyles) is not safe, use int.__new__()``
+class PlayStyles(BaseModel, IntFlag, metaclass=ListEnumMeta):
     MOUSE = 1
     KEYBOARD = 2
     TABLET = 4
@@ -62,7 +68,7 @@ class PlayStyles(IntFlag, metaclass=ListEnumMeta):
             return PlayStyles.TOUCH
         return super()._missing_(value)
 
-class RankStatus(Enum):
+class RankStatus(EnumModel):
     GRAVEYARD = -2
     WIP = -1
     PENDING = 0
@@ -94,12 +100,12 @@ class RankStatus(Enum):
             return cls(4)
         return super()._missing_(value)
 
-class UserAccountHistoryType(Enum):
+class UserAccountHistoryType(EnumModel):
     NOTE = "note"
     RESTRICTION = "restriction"
     SILENCE = "silence"
 
-class MessageType(Enum):
+class MessageType(EnumModel):
     DISQUALIFY = "disqualify"
     HYPE = "hype"
     MAPPER_NOTE = "mapper_note"
@@ -109,7 +115,7 @@ class MessageType(Enum):
     REVIEW = "review"
     SUGGESTION = "suggestion"
 
-class BeatmapsetEventType(Enum):
+class BeatmapsetEventType(EnumModel):
     APPROVE =  "approve"
     BEATMAP_OWNER_CHANGE = "beatmap_owner_change"
     DISCUSSION_DELETE =  "discussion_delete"
@@ -138,27 +144,27 @@ class BeatmapsetEventType(Enum):
     REMOVE_FROM_LOVED = "remove_from_loved"
     NSFW_TOGGLE = "nsfw_toggle"
 
-class BeatmapsetDownload(Enum):
+class BeatmapsetDownload(EnumModel):
     ALL = "all"
     NO_VIDEO = "no_video"
     DIRECT = "direct"
 
-class UserListFilters(Enum):
+class UserListFilters(EnumModel):
     ALL = "all"
     ONLINE = "online"
     OFFLINE = "offline"
 
-class UserListSorts(Enum):
+class UserListSorts(EnumModel):
     LAST_VISIT = "last_visit"
     RANK = "rank"
     USERNAME = "username"
 
-class UserListViews(Enum):
+class UserListViews(EnumModel):
     CARD = "card"
     LIST = "list"
     BRICK = "brick"
 
-class KudosuAction(Enum):
+class KudosuAction(EnumModel):
     # TODO ideally these wouldn't be prefixed with ``vote``. They aren't
     # documented as such in https://osu.ppy.sh/docs/index.html#kudosuhistory,
     # but that's what the api returns
@@ -166,7 +172,7 @@ class KudosuAction(Enum):
     RESET = "vote.reset"
     REVOKE = "vote.revoke"
 
-class UserBeatmapType(Enum):
+class UserBeatmapType(EnumModel):
     FAVOURITE = "favourite"
     GRAVEYARD = "graveyard"
     LOVED = "loved"
@@ -174,11 +180,11 @@ class UserBeatmapType(Enum):
     RANKED_AND_APPROVED = "ranked_and_approved"
     UNRANKED = "unranked"
 
-class BeatmapDiscussionPostSort(Enum):
+class BeatmapDiscussionPostSort(EnumModel):
     NEW = "id_desc"
     OLD = "id_asc"
 
-class EventType(Enum):
+class EventType(EnumModel):
     ACHIEVEMENT = "achievement"
     BEATMAP_PLAYCOUNT = "beatmapPlaycount"
     BEATMAPSET_APPROVE = "beatmapsetApprove"
@@ -196,7 +202,7 @@ class EventType(Enum):
 # TODO this is just a subset of ``RankStatus``, and is only (currently) used for
 # ``EventType.BEATMAPSET_APPROVE``. Find some way to de-duplicate? Could move to
 # ``RankStatus``, but then how to enforce taking on only a subset of values?
-class BeatmapsetApproval(Enum):
+class BeatmapsetApproval(EnumModel):
     RANKED = "ranked"
     APPROVED = "approved"
     QUALIFIED = "qualified"
@@ -208,13 +214,13 @@ class BeatmapsetApproval(Enum):
 # ==================
 
 
-class UserRelationType(Enum):
+class UserRelationType(EnumModel):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserRelationTransformer.php#L20
     FRIEND = "friend"
     BLOCK = "block"
 
-class Grade(Enum):
+class Grade(EnumModel):
     SSH = "XH"
     SS = "X"
     SH = "SH"
@@ -231,12 +237,12 @@ class Grade(Enum):
 
 
 @dataclass
-class Failtimes:
+class Failtimes(Model):
     exit: Optional[List[int]]
     fail: Optional[List[int]]
 
 @dataclass
-class Ranking:
+class Ranking(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/CountryTransformer.php#L30
     active_users: int
     play_count: int
@@ -244,7 +250,7 @@ class Ranking:
     performance: int
 
 @dataclass
-class Country:
+class Country(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/CountryTransformer.php#L10
     code: str
     name: str
@@ -255,7 +261,7 @@ class Country:
     ranking: Optional[Ranking]
 
 @dataclass
-class Cover:
+class Cover(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserCompactTransformer.php#L158
     custom_url: str
     url: str
@@ -264,13 +270,13 @@ class Cover:
 
 
 @dataclass
-class ProfileBanner:
+class ProfileBanner(Model):
     id: int
     tournament_id: int
     image: str
 
 @dataclass
-class UserAccountHistory:
+class UserAccountHistory(Model):
     description: Optional[str]
     type: UserAccountHistoryType
     timestamp: Datetime
@@ -278,14 +284,14 @@ class UserAccountHistory:
 
 
 @dataclass
-class UserBadge:
+class UserBadge(Model):
     awarded_at: Datetime
     description: str
     image_url: str
     url: str
 
 @dataclass
-class UserGroup:
+class UserGroup(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserGroupTransformer.php#L10
     id: int
     identifier: str
@@ -297,7 +303,7 @@ class UserGroup:
     is_probationary: bool
 
 @dataclass
-class Covers:
+class Covers(Model):
     """
     https://osu.ppy.sh/docs/index.html#beatmapsetcompact-covers
     """
@@ -311,7 +317,7 @@ class Covers:
     slimcover_2x: str
 
 @dataclass
-class Statistics:
+class Statistics(Model):
     count_50: int
     count_100: int
     count_300: int
@@ -320,32 +326,32 @@ class Statistics:
     count_miss: int
 
 @dataclass
-class Availability:
+class Availability(Model):
     download_disabled: bool
     more_information: Optional[str]
 
 @dataclass
-class Hype:
+class Hype(Model):
     current: int
     required: int
 
 @dataclass
-class Nominations:
+class Nominations(Model):
     current: int
     required: int
 
 @dataclass
-class Kudosu:
+class Kudosu(Model):
     total: int
     available: int
 
 @dataclass
-class KudosuGiver:
+class KudosuGiver(Model):
     url: str
     username: str
 
 @dataclass
-class KudosuPost:
+class KudosuPost(Model):
     url: Optional[str]
     # will be "[deleted beatmap]" for deleted beatmaps. TODO codify this
     # somehow? another enum perhaps? see
@@ -353,23 +359,23 @@ class KudosuPost:
     title: str
 
 @dataclass
-class EventUser:
+class EventUser(Model):
     username: str
     url: str
     previousUsername: Optional[str]
 
 @dataclass
-class EventBeatmap:
+class EventBeatmap(Model):
     title: str
     url: str
 
 @dataclass
-class EventBeatmapset:
+class EventBeatmapset(Model):
     title: str
     url: str
 
 @dataclass
-class EventAchivement:
+class EventAchivement(Model):
     icon_url: str
     id: int
     name: str
@@ -388,28 +394,28 @@ class EventAchivement:
 # ===================
 
 @dataclass
-class UserMonthlyPlaycount:
+class UserMonthlyPlaycount(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserMonthlyPlaycountTransformer.php
     start_date: Datetime
     count: int
 
 @dataclass
-class UserPage:
+class UserPage(Model):
     # undocumented (and not a class on osu-web)
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserCompactTransformer.php#L270
     html: str
     raw: str
 
 @dataclass
-class UserLevel:
+class UserLevel(Model):
     # undocumented (and not a class on osu-web)
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserStatisticsTransformer.php#L27
     current: int
     progress: int
 
 @dataclass
-class UserGradeCounts:
+class UserGradeCounts(Model):
     # undocumented (and not a class on osu-web)
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserStatisticsTransformer.php#L43
     ss: int
@@ -419,21 +425,21 @@ class UserGradeCounts:
     a: int
 
 @dataclass
-class UserReplaysWatchedCount:
+class UserReplaysWatchedCount(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserReplaysWatchedCountTransformer.php
     start_date: Datetime
     count: int
 
 @dataclass
-class UserAchievement:
+class UserAchievement(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserAchievementTransformer.php#L10
     achieved_at: Datetime
     achievement_id: int
 
 @dataclass
-class UserProfileCustomization:
+class UserProfileCustomization(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserCompactTransformer.php#L363
     # https://github.com/ppy/osu-web/blob/master/app/Models/UserProfileCustomization.php
@@ -451,13 +457,13 @@ class UserProfileCustomization:
     user_list_view: Optional[UserListViews]
 
 @dataclass
-class RankHistory:
+class RankHistory(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/RankHistoryTransformer.php
     mode: GameMode
     data: List[int]
 
 @dataclass
-class Weight:
+class Weight(Model):
     percentage: float
     pp: float

--- a/ossapi/mod.py
+++ b/ossapi/mod.py
@@ -1,3 +1,5 @@
+from ossapi.utils import BaseModel
+
 int_to_mod = {
     0          : ["NM",       "NoMod"],
     1 << 0     : ["NF",      "NoFail"],
@@ -34,7 +36,7 @@ int_to_mod = {
 }
 
 
-class ModCombination():
+class ModCombination(BaseModel):
     """
     An osu! mod combination.
 

--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 from ossapi.mod import Mod
 from ossapi.enums import *
-from ossapi.utils import Datetime
+from ossapi.utils import Datetime, Model
 
 T = TypeVar("T")
 
@@ -22,7 +22,7 @@ is, not that the api actually lets any type be returned there.
 # =================
 
 @dataclass
-class UserCompact:
+class UserCompact(Model):
     """
     https://osu.ppy.sh/docs/index.html#usercompact
     """
@@ -114,7 +114,7 @@ class User(UserCompact):
 
 
 @dataclass
-class BeatmapCompact:
+class BeatmapCompact(Model):
     # required fields
     # ---------------
     difficulty_rating: float
@@ -163,7 +163,7 @@ class Beatmap(BeatmapCompact):
 
 
 @dataclass
-class BeatmapsetCompact:
+class BeatmapsetCompact(Model):
     """
     https://osu.ppy.sh/docs/index.html#beatmapsetcompact
     """
@@ -225,11 +225,11 @@ class Beatmapset(BeatmapsetCompact):
 
 
 @dataclass
-class Match:
+class Match(Model):
     pass
 
 @dataclass
-class Score:
+class Score(Model):
     """
     https://osu.ppy.sh/docs/index.html#score
     """
@@ -258,18 +258,18 @@ class Score:
     match: Optional[Match]
 
 @dataclass
-class BeatmapUserScore:
+class BeatmapUserScore(Model):
     position: int
     score: Score
 
 @dataclass
-class BeatmapScores:
+class BeatmapScores(Model):
     scores: List[Score]
     userScore: Optional[BeatmapUserScore]
 
 
 @dataclass
-class CommentableMeta:
+class CommentableMeta(Model):
     # this class is currently not following the documentation in order to work
     # around https://github.com/ppy/osu-web/issues/7317. Will be updated when
     # that issue is resolved (one way or the other).
@@ -282,7 +282,7 @@ class CommentableMeta:
     owner_title: Optional[str]
 
 @dataclass
-class Comment:
+class Comment(Model):
     commentable_id: int
     commentable_type: str
     created_at: Datetime
@@ -308,7 +308,7 @@ class Comment:
 # We do, however, have to tell our code what type each attribute is, if we
 # receive that atttribute. So ``__annotations`` will need updating as we
 # encounter new cursor attributes.
-class Cursor(SimpleNamespace):
+class Cursor(SimpleNamespace, Model):
     __annotations__ = {
         "created_at": Datetime,
         "id": int,
@@ -322,7 +322,7 @@ class Cursor(SimpleNamespace):
     }
 
 @dataclass
-class CommentBundle:
+class CommentBundle(Model):
     commentable_meta: List[CommentableMeta]
     comments: List[Comment]
     has_more: bool
@@ -340,29 +340,29 @@ class CommentBundle:
 
 
 @dataclass
-class ForumPost:
+class ForumPost(Model):
     pass
 
 @dataclass
-class ForumTopic:
+class ForumTopic(Model):
     pass
 
 
 @dataclass
-class ForumTopicAndPosts:
+class ForumTopicAndPosts(Model):
     cursor: Cursor
     search: str
     posts: List[ForumPost]
     topic: ForumTopic
 
 @dataclass
-class SearchResult(Generic[T]):
+class SearchResult(Generic[T], Model):
     data: List[T]
     total: int
 
 
 @dataclass
-class WikiPage:
+class WikiPage(Model):
     layout: str
     locale: str
     markdown: str
@@ -372,12 +372,12 @@ class WikiPage:
     title: str
 
 @dataclass
-class Search:
+class Search(Model):
     user: Optional[SearchResult[UserCompact]]
     wiki_page: Optional[SearchResult[WikiPage]]
 
 @dataclass
-class Spotlight:
+class Spotlight(Model):
     end_date: Datetime
     id: int
     mode_specific: bool
@@ -387,11 +387,11 @@ class Spotlight:
     type: str
 
 @dataclass
-class Spotlights:
+class Spotlights(Model):
     spotlights: List[Spotlight]
 
 @dataclass
-class Rankings:
+class Rankings(Model):
     beatmapsets: Optional[List[Beatmapset]]
     cursor: Cursor
     ranking: List[UserStatistics]
@@ -399,7 +399,7 @@ class Rankings:
     total: int
 
 @dataclass
-class BeatmapsetDiscussionPost:
+class BeatmapsetDiscussionPost(Model):
     id: int
     beatmapset_discussion_id: int
     user_id: int
@@ -412,7 +412,7 @@ class BeatmapsetDiscussionPost:
     deleted_at: Optional[Datetime]
 
 @dataclass
-class BeatmapsetDiscussion:
+class BeatmapsetDiscussion(Model):
     id: int
     beatmapset_id: int
     beatmap_id: int
@@ -438,7 +438,7 @@ class BeatmapsetDiscussion:
     beatmapset: Optional[BeatmapsetCompact]
 
 @dataclass
-class BeatmapsetDiscussionVote:
+class BeatmapsetDiscussionVote(Model):
     score: int
     user_id: int
 
@@ -450,7 +450,7 @@ class BeatmapsetDiscussionVote:
     # updated_at: Datetime
 
 @dataclass
-class KudosuHistory:
+class KudosuHistory(Model):
     id: int
     action: KudosuAction
     amount: int
@@ -465,7 +465,7 @@ class KudosuHistory:
     details: Any
 
 @dataclass
-class BeatmapPlaycount:
+class BeatmapPlaycount(Model):
     beatmap_id: int
     beatmap: Optional[BeatmapCompact]
     beatmapset: Optional[BeatmapsetCompact]
@@ -485,7 +485,7 @@ class BeatmapPlaycount:
 # down our members. This affords us total control over our instantiation while
 # still allowing us to benefit from the annotation resolution of our nested
 # members.
-class _Event:
+class _Event(Model):
     def __new__(cls, **data):
         mapping = {
             EventType.ACHIEVEMENT: AchievementEvent,
@@ -584,7 +584,7 @@ class UsernameChangeEvent(Event):
 # ===================
 
 @dataclass
-class BeatmapSearchResult:
+class BeatmapSearchResult(Model):
     beatmapsets: List[Beatmapset]
     cursor: Cursor
     recommended_difficulty: float
@@ -593,12 +593,12 @@ class BeatmapSearchResult:
     search: Any
 
 @dataclass
-class BeatmapsetDiscussionReview:
+class BeatmapsetDiscussionReview(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Libraries/BeatmapsetDiscussionReview.php
     max_blocks: int
 
 @dataclass
-class BeatmapsetEventComment:
+class BeatmapsetEventComment(Model):
     # the values returned by the api for this class depends on
     # `BeatmapsetEvent.type`. Until we have a clean way of dealing with that,
     # mark everything as optional.
@@ -618,7 +618,7 @@ class BeatmapsetEventComment:
     reason: Optional[str]
 
 @dataclass
-class BeatmapsetDiscussionPostResult:
+class BeatmapsetDiscussionPostResult(Model):
     # This is for the ``/beatmapsets/discussions/posts`` endpoint because
     # the actual return type of that endpoint doesn't match the docs at
     # https://osu.ppy.sh/docs/index.html#get-beatmapset-discussion-posts. TODO
@@ -630,7 +630,7 @@ class BeatmapsetDiscussionPostResult:
     users: List[UserCompact]
 
 @dataclass
-class BeatmapsetEvent:
+class BeatmapsetEvent(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Models/BeatmapsetEvent.php
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/BeatmapsetEventTransformer.php
     id: int
@@ -644,14 +644,14 @@ class BeatmapsetEvent:
 
 
 @dataclass
-class ModdingHistoryEventsBundle:
+class ModdingHistoryEventsBundle(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Libraries/ModdingHistoryEventsBundle.php#L84
     events: List[BeatmapsetEvent]
     reviewsConfig: BeatmapsetDiscussionReview
     users: List[UserCompact]
 
 @dataclass
-class UserRelation:
+class UserRelation(Model):
     # undocumented (and not a class on osu-web)
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserRelationTransformer.php#L16
     target_id: int
@@ -664,7 +664,7 @@ class UserRelation:
 
 
 @dataclass
-class UserStatistics:
+class UserStatistics(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserStatisticsTransformer.php
     level: UserLevel
@@ -689,7 +689,7 @@ class UserStatistics:
     variants: Optional[Any]
 
 @dataclass
-class UserStatisticsRulesets:
+class UserStatisticsRulesets(Model):
     # undocumented
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserStatisticsRulesetsTransformer.php
     osu: Optional[UserStatistics]

--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -345,7 +345,10 @@ class OssapiV2:
                 type_ = args[0]
             new_value = []
             for entry in value:
-                entry = self._instantiate(type_, **entry)
+                if is_base_type(type_):
+                    entry = type_(entry)
+                else:
+                    entry = self._instantiate(type_, **entry)
                 # if the list entry is a model type, we need to resolve it
                 # instead of just sticking it into the list, since its children
                 # might still be dicts and not model instances.


### PR DESCRIPTION
This pr requires all models to subclass `Model`, and creates a nicer way to register models as "base" models: subclass `BaseModel` instead.  There is no longer anything special about a dataclass in terms of it being a model type, though we will of course continue to use dataclasses as the primary model types. They just subclass `Model` as well now.

Although these classes are effectively marker interfaces currently, with no methods, this also paves the way to adding methods to all model classes if we need to do so in the future.