### PR TITLE
expose `override_types` and `override_class` in `Model`

### DIFF
--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -366,6 +366,11 @@ class KudosuPost(Model):
     title: str
 
 @dataclass
+class KudosuVote(Model):
+    user_id: int
+    score: int
+
+@dataclass
 class EventUser(Model):
     username: str
     url: str

--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -306,7 +306,7 @@ class UserGroup(Model):
     identifier: str
     name: str
     short_name: str
-    colour: str
+    colour: Optional[str]
     description: Optional[GroupDescription]
     playmodes: Optional[List[GameMode]]
     is_probationary: bool

--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -263,10 +263,10 @@ class Country(Model):
 @dataclass
 class Cover(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Transformers/UserCompactTransformer.php#L158
-    custom_url: str
+    custom_url: Optional[str]
     url: str
     # api should really return an int here instead...open an issue?
-    id: str
+    id: Optional[str]
 
 
 @dataclass

--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -414,8 +414,10 @@ class BeatmapsetDiscussionPost(Model):
     id: int
     beatmapset_discussion_id: int
     user_id: int
-    last_editor_id: int
-    deleted_by_id: int
+    # documented as non-optional
+    last_editor_id: Optional[int]
+    # documented as non-optional
+    deleted_by_id: Optional[int]
     system: bool
     message: str
     created_at: Datetime
@@ -426,9 +428,11 @@ class BeatmapsetDiscussionPost(Model):
 class BeatmapsetDiscussion(Model):
     id: int
     beatmapset_id: int
-    beatmap_id: int
+    # documented as non-optional
+    beatmap_id: Optional[int]
     user_id: int
-    deleted_by_id: int
+    # documented as non-optional
+    deleted_by_id: Optional[int]
     message_type: MessageType
     parent_id: Optional[int]
     # a point of time which is ``timestamp`` milliseconds into the map
@@ -439,11 +443,12 @@ class BeatmapsetDiscussion(Model):
     created_at: Datetime
     updated_at: Datetime
     deleted_at: Optional[Datetime]
-    last_post_at: Datetime
+    # documented as non-optional
+    last_post_at: Optional[Datetime]
     kudosu_denied: bool
-    # documented as being non-optional but in reality it's not always returned
+    # documented as non-optional
     starting_post: Optional[BeatmapsetDiscussionPost]
-    # here too
+    # documented as non-optional
     posts: Optional[List[BeatmapsetDiscussionPost]]
     beatmap: Optional[BeatmapCompact]
     beatmapset: Optional[BeatmapsetCompact]

--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -39,7 +39,9 @@ class UserCompact(Model):
     is_supporter: bool
     last_visit: Optional[Datetime]
     pm_friends_only: bool
-    profile_colour: str
+    # TODO pretty sure this needs to be optional but it's not documented as
+    # such, open an issue?
+    profile_colour: Optional[str]
     username: str
 
     # optional fields
@@ -191,7 +193,7 @@ class BeatmapsetCompact(Model):
     nsfw: bool
     # documented as being in ``Beatmapset`` only, but returned by
     # ``api.beatmapset_events`` which uses a ``BeatmapsetCompact``.
-    hype: Hype
+    hype: Optional[Hype]
 
     # optional fields
     # ---------------
@@ -246,7 +248,9 @@ class Score(Model):
     max_combo: int
     perfect: bool
     statistics: Statistics
-    pp: float
+    # documented as non-optional in docs but broken beatmaps like acid rain
+    # (1981090) have scores with null pp values. TODO open issue
+    pp: Optional[float]
     rank: Grade
     created_at: Datetime
     mode: GameMode

--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -456,7 +456,7 @@ class OssapiV2:
                     self.log.info(f"ignoring unexpected parameter `{k}` from api "
                         f"response for type {type_}")
         try:
-            val = type_(**kwargs)
+            val = type_(**kwargs_)
         except TypeError as e:
             raise TypeError(f"type error while instantiating class {type_}: "
                 f"{str(e)}") from e

--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -280,6 +280,8 @@ class OssapiV2:
         # return annotations for attributes defined in ``obj`` and not its
         # inherited attributes.
         annotations = get_type_hints(type(obj))
+        override_annotations = obj.override_types()
+        annotations = {**annotations, **override_annotations}
         self.log.debug(f"resolving annotations for type {type(obj)}")
         for attr, value in obj.__dict__.items():
             # we use this attribute later if we encounter an attribute which
@@ -287,23 +289,26 @@ class OssapiV2:
             # anything with it now.
             if attr == "__orig_class__":
                 continue
+            type_ = annotations[attr]
             # when we instantiate types, we explicitly fill in optional
-            # attributes with ``None``. This means they're in ``obj.__dict__``
-            # and so we see them here. We don't want to do anything with them,
-            # so skip.
-            if value is None:
+            # attributes with ``None``. We want to skip these, but only if the
+            # attribute is actually annotated as optional, otherwise we would be
+            # skipping fields that are null which aren't supposed to be, and
+            # prevent that error from being caught.
+            if value is None and is_optional(type_):
                 continue
             self.log.debug(f"resolving attribute {attr}")
 
-            type_ = annotations[attr]
-            value = self._instantiate_type(type_, value, obj)
+            value = self._instantiate_type(type_, value, obj, attr_name=attr)
             if not value:
                 continue
             setattr(obj, attr, value)
         self.log.debug(f"resolved annotations for type {type(obj)}")
         return obj
 
-    def _instantiate_type(self, type_, value, obj=None):
+    def _instantiate_type(self, type_, value, obj=None, attr_name=None):
+        # ``attr_name`` is purely for debugging, it's the name of the attribute
+        # being instantiated
         origin = get_origin(type_)
         args = get_args(type_)
 
@@ -324,7 +329,8 @@ class OssapiV2:
         if is_primitive_type(type_):
             if not is_compatible_type(value, type_):
                 raise TypeError(f"expected type {type_} for value {value}, got "
-                    f"type {type(value)}")
+                    f"type {type(value)}"
+                    f" (for attribute: {attr_name})" if attr_name else "")
 
         if is_base_model_type(type_):
             self.log.debug(f"instantiating base type {type_}")
@@ -349,7 +355,7 @@ class OssapiV2:
                 if is_base_model_type(type_):
                     entry = type_(entry)
                 else:
-                    entry = self._instantiate(type_, **entry)
+                    entry = self._instantiate(type_, entry)
                 # if the list entry is a high (non-base) model type, we need to
                 # resolve it instead of just sticking it into the list, since
                 # its children might still be dicts and not model instances.
@@ -367,14 +373,14 @@ class OssapiV2:
         # ``type_``.
         if not is_model_type(type_) and not is_model_type(origin):
             return None
-        value = self._instantiate(type_, **value)
+        value = self._instantiate(type_, value)
         # we need to resolve the annotations of any nested model types before we
         # set the attribute. This recursion is well-defined because the base
         # case is when ``value`` has no model types, which will always happen
         # eventually.
         return self._resolve_annotations(value)
 
-    def _instantiate(self, type_, **kwargs):
+    def _instantiate(self, type_, kwargs):
         self.log.debug(f"instantiating type {type_}")
         # we need a special case to handle when ``type_`` is a
         # ``_GenericAlias``. I don't fully understand why this exception is
@@ -383,7 +389,8 @@ class OssapiV2:
         # we need to extract the type to use for the init signature and the type
         # hints from a ``_GenericAlias`` if we see one, as standard methods
         # won't work.
-
+        override_type = type_.override_class(kwargs)
+        type_ = override_type or type_
         signature_type = type_
         try:
             type_hints = get_type_hints(type_)
@@ -429,21 +436,7 @@ class OssapiV2:
 
         # Some special classes take arbitrary parameters, so we can't evaluate
         # whether a parameter is unexpected or not until we instantiate it.
-        # TODO This is actually rather problematic for us in the case of
-        # ``_Event``, because ``_Event`` will switch on the input and hand off
-        # instantion to some *other*, more specific, ``Event`` subclass. Ideally
-        # we'd like to be able to determine the parameters from this current
-        # level, but we can't do so without going down to the level of
-        # ``_Event``.
-        # The temporary solution is to ignore ``_Event`` types when checking for
-        # unexpected paramters, but this means that any parameters to ``_Event``
-        # which actually *are* unexpected will error instead of being caught by
-        # us. Not good.
-        # Ideally we'd have some way for ``_Event`` to expose to us what
-        # parameters it expects. That requires formalizing the hooking that
-        # ``_Event`` is currently doing and is not a trivial amount of work, and
-        # may not even be the correct path forward.
-        if isinstance(type_, type) and issubclass(type_, (Cursor, _Event)):
+        if isinstance(type_, type) and issubclass(type_, Cursor):
             kwargs_ = kwargs
         else:
             for k, v in kwargs.items():

--- a/ossapi/utils.py
+++ b/ossapi/utils.py
@@ -35,10 +35,33 @@ class Model:
     instead.
     """
     def override_types(self):
+        """
+        Sometimes, the types of attributes in models depends on the value of
+        other fields in that model. By overriding this method, models can return
+        "override types", which overrides the static annotation of attributes
+        and tells ossapi to use the returned type to instantiate the attribute
+        instead.
+
+        This method should return a mapping of ``attribute_name`` to
+        ``intended_type``.
+        """
         return {}
 
     @classmethod
     def override_class(cls, _data):
+        """
+        This method addressess a shortcoming in ``override_types`` in order to
+        achieve full coverage of the intended feature of overriding types.
+
+        The model that we want to override types for may be at the very top of
+        the hierarchy, meaning we can't go any higher and find a model for which
+        we can override ``override_types`` to customize this class' type.
+
+        A possible solution for this is to create a wrapper class one step above
+        it; however, this is both dirty and may not work (I haven't actually
+        tried it). So this method provides a way for a model to override its
+        *own* type (ie class) at run-time.
+        """
         return None
 
 class BaseModel(Model):

--- a/ossapi/utils.py
+++ b/ossapi/utils.py
@@ -34,7 +34,12 @@ class Model:
     its own members and cleanup after instantion, subclass ``BaseModel``
     instead.
     """
-    pass
+    def override_types(self):
+        return {}
+
+    @classmethod
+    def override_class(cls, _data):
+        return None
 
 class BaseModel(Model):
     """

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -34,7 +34,15 @@ class TestBeatmap(TestCase):
 
 class TestBeatmapsetEvents(TestCase):
     def test_deserialize(self):
-        api.beatmapsets_events(types=[BeatmapsetEventType.ISSUE_REOPEN])
+        api.beatmapsets_events()
+
+    def test_all_types(self):
+        # beatmapsets_events is a really complicated endpoint in terms of return
+        # types. We want to make sure both that we're not doing anything wrong,
+        # and the osu! api isn't doing anything wrong by returning something
+        # that doesn't match their documentation.
+        for event_type in BeatmapsetEventType:
+            api.beatmapsets_events(types=[event_type])
 
 class TestRanking(TestCase):
     def test_deserialize(self):


### PR DESCRIPTION
This adds the two aforementioned methods to `Model` which sub-models can override to customize the types of themselves, or their attributes. I've converted our `_Event` class to use this new mechanism:


```python
# before
class _Event(Model):
    def __new__(cls, **data):

# after
class _Event(Model):
    @classmethod
    def override_class(cls, data):
```

and I use `override_types` to formalize the types relationship in `BeatmapsetEvent` (which was an absolute pain by the way, that's one very complex endpoint).

see documentation for each of these new methods for details on their purpose and intended usage.

This PR also makes quite a few model attributes nullable, since apparently the `BeatmapsetEvent` like to return weird responses with null values which the api docs fail to mention. Still unsure if this is an issue that needs to be fixed at the `BeatmapsetEvent` level, or the other-models level.
