### PR TITLE
Missing cursor attribute `play_count` for beatmapsets search with sort query

### DIFF
--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -355,6 +355,7 @@ class Cursor(SimpleNamespace, Model):
         "queued_at": str,
         "approved_date": Datetime,
         "last_update": str,
+        "play_count": str,
         "votes_count": int,
         "page": int,
         "limit": int,


### PR DESCRIPTION
The cursor for the `/beatmapsets/search/?sort=plays_desc` endpoint (which I'm currently invoking directly) is missing the `play_count` attribute which causes the client to crash:
```
<class 'ossapi.models.BeatmapsetSearchResult'> cursor
{'play_count': '23628495', '_id': '219380'}
<class 'ossapi.models.Cursor'> play_count
<...>
    type_ = annotations[attr]
KeyError: 'play_count'
```
This PR adds the attribute. I'm not sure why it's a string instead of an integer but oh well.
