### PR TITLE
Fix non-ascii characters when using serialize_model()

### DIFF
--- a/ossapi/encoder.py
+++ b/ossapi/encoder.py
@@ -28,4 +28,4 @@ class ModelEncoder(JSONEncoder):
 
 
 def serialize_model(model, ensure_ascii=False, **kwargs):
-    return json.dumps(model, cls=ModelEncoder,  ensure_ascii=False, **kwargs)
+    return json.dumps(model, cls=ModelEncoder,  ensure_ascii=ensure_ascii, **kwargs)


### PR DESCRIPTION
Fixes responses for requests to beatmaps with Unicode titles:

Formerly

```python
bmap = api.beatmap(2293914)
print(serialize_model(bmap))
```

would return:

`..., "beatmapset": {"artist": "Sally", "artist_unicode": "\u30b5\u30ea\u30fc", ...`

With this change it returns:

`..., "beatmapset": {"artist": "Sally", "artist_unicode": "サリー", ...`

unless `ensure_ascii=True` is explicitly provided.