### PR TITLE
add User.guest_beatmapset_count

### DIFF
--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -111,6 +111,8 @@ class UserCompact(Model):
     friends: Optional[List[UserRelation]]
     graveyard_beatmapset_count: Optional[int]
     groups: Optional[List[UserGroup]]
+    # undocumented
+    guest_beatmapset_count: Optional[int]
     is_admin: Optional[bool]
     is_bng: Optional[bool]
     is_full_bn: Optional[bool]


### PR DESCRIPTION
This attribute isn't documented, but [is referenced in osu-web](https://github.com/ppy/osu-web/blob/1d73786490e93a1626b3f94fa86e0731e9966575/resources/assets/lib/profile-page/beatmapsets.tsx#L29) so I figured I would give it a shot.

![image](https://user-images.githubusercontent.com/8301262/167353622-7d4a1c43-86bd-4738-b065-b8cf36386f10.png)
