### PR TITLE
peppy changed type of download_disabled

### DIFF
--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Union
 
 from ossapi.utils import (EnumModel, Datetime, Model, Field, IntFlagModel)
 
@@ -376,7 +376,7 @@ class Statistics(Model):
     count_miss: int
 
 class Availability(Model):
-    download_disabled: bool
+    download_disabled: Union[bool, int]
     more_information: Optional[str]
 
 class Hype(Model):


### PR DESCRIPTION
HI! It seems our favorite developer changed the type of object, which turned my api calls into a pumpkin. I'm not quite sure if peppy left the type that way forever or if it's temporary and wrapped in Union for now, if it's worth making just an int, I'll fix it :)

![image](https://user-images.githubusercontent.com/23283658/193368442-16919a01-be59-41c5-80e7-ccaae6f2c976.png)