### PR TITLE
fix(types): Resolve audio_volume type mismatch with API response

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -1641,7 +1641,7 @@ Enums
       :type: bool | None
 
    .. py:attribute:: audio_volume
-      :type: int | None
+      :type: float | None
 
    .. py:attribute:: beatmapset_download
       :type: BeatmapsetDownload | None

--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -874,7 +874,7 @@ class UserProfileCustomization(Model):
     # https://github.com/ppy/osu-web/blob/master/app/Models/UserProfileCustomization.php
     audio_autoplay: Optional[bool]
     audio_muted: Optional[bool]
-    audio_volume: Optional[int]
+    audio_volume: Optional[float]
     beatmapset_download: Optional[BeatmapsetDownload]
     beatmapset_show_nsfw: Optional[bool]
     beatmapset_title_show_original: Optional[bool]


### PR DESCRIPTION
This pull request proposes updating the **UserProfileCustomization** API model to match the `audio_volume` field type used in the official osu!web API response

Previously, the field was typed as an `int`
but the official API currently returns `float`
as defined in:
[Line 132: osu-web/app/Models/UserProfileCustomization.php](https://github.com/ppy/osu-web/blob/d13e37bb2bdfc8aa85985cf4171986df91acbd38/app/Models/UserProfileCustomization.php#L132)


I discovered the issue when my app partially stopped working with the following error

> TypeError: expected type <class 'int'> for value 0.1039990234375, got type <class 'float'> (for attribute: audio_volume)

Stack trace included:

```python
TypeError: expected type <class 'int'> for value 0.1039990234375, got type <class 'float'> (for attribute: audio_volume)
Traceback (most recent call last):
  File "/../osuverify/osu_api.py", line 117, in validate
    profile : ossapi.User = await user_osu_api_v2.get_me()
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 1991, in get_me
    return await self._get(User, f"/me/{mode.value if mode else ''}")
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 681, in _get
    return await self._request(type_, "GET", url, params=params)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 670, in _request
    return self._instantiate_type(type_, json_)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 871, in _instantiate_type
    return self._resolve_annotations(value)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 784, in _resolve_annotations
    value = self._instantiate_type(type_, value, obj, attr_name=attr)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 871, in _instantiate_type
    return self._resolve_annotations(value)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 784, in _resolve_annotations
    value = self._instantiate_type(type_, value, obj, attr_name=attr)
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 823, in _instantiate_type
    _check_primitive_type()
  File "/usr/local/lib/python3.9/dist-packages/ossapi/ossapiv2_async.py", line 818, in _check_primitive_type
    raise TypeError(f"expected type {type_} for value {value}, got "
```

The change is limited to the type definition in enums:
```diff
# ossapi\enums.py
class UserProfileCustomization(Model):
-    audio_volume: Optional[int]
+    audio_volume: Optional[float]
```
Documentation has been updated accordingly:
```diff
# docs\api-reference.rst
 class UserProfileCustomization:
   .. py:attribute:: audio_volume
-      :type: int | None
+      :type: float | None
```
(diffs above are just useful quick visual reference)

Thank you for reviewing this!